### PR TITLE
AUTH-2235: Validate XML in SAML

### DIFF
--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -753,10 +753,10 @@ func (test *IdentityProviderTest) TestMakeResponse(c *C) {
 		"          <ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/>\n"+
 		"        </ds:Transforms>\n"+
 		"        <ds:DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/>\n"+
-		"        <ds:DigestValue>fGqTakd3fq3s1utz7xTvzJtQc+E=</ds:DigestValue>\n"+
+		"        <ds:DigestValue>KsbyS2V2/QCarAksPQyV5s3PVDk=</ds:DigestValue>\n"+
 		"      </ds:Reference>\n"+
 		"    </ds:SignedInfo>\n"+
-		"    <ds:SignatureValue>yXty6VQCvvF6QAR+vXZtLq2/r8Jt2B9jExD1vVfvWY+S1sKPZbNbaKl69YHYXU8lkhymlVNaMsaezQWDisbNfPe0R0UWysp2rfIXpVDGTdp/YHPj1MIODMPrlgWFfcJjgGxox0tTVzaFyOJFSPhn4G8wEI86WHuePnjRcenfxyk=</ds:SignatureValue>\n"+
+		"    <ds:SignatureValue>paj/Jq/TTvYXu35Jtyevmu8bn2DZecfaj/wu8l7mY2sN++w9QL/sLZoyyJk6WsAsS0NMMOt8o5WN7EU+bVlbQ6VQbf2VO9gEPbONMdpQ8gfrvMiLo5vRS22iRaPehIH8gvWxAq64vWWt94OihpndNRt782K/0h/NvXBj+4vK7V8=</ds:SignatureValue>\n"+
 		"    <ds:KeyInfo>\n"+
 		"      <ds:X509Data>\n"+
 		"        <ds:X509Certificate>MIIB7zCCAVgCCQDFzbKIp7b3MTANBgkqhkiG9w0BAQUFADA8MQswCQYDVQQGEwJVUzELMAkGA1UECAwCR0ExDDAKBgNVBAoMA2ZvbzESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTEzMTAwMjAwMDg1MVoXDTE0MTAwMjAwMDg1MVowPDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkdBMQwwCgYDVQQKDANmb28xEjAQBgNVBAMMCWxvY2FsaG9zdDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1PMHYmhZj308kWLhZVT4vOulqx/9ibm5B86fPWwUKKQ2i12MYtz07tzukPymisTDhQaqyJ8Kqb/6JjhmeMnEOdTvSPmHO8m1ZVveJU6NoKRn/mP/BD7FW52WhbrUXLSeHVSKfWkNk6S4hk9MV9TswTvyRIKvRsw0X/gfnqkroJcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCMMlIO+GNcGekevKgkakpMdAqJfs24maGb90DvTLbRZRD7Xvn1MnVBBS9hzlXiFLYOInXACMW5gcoRFfeTQLSouMM8o57h0uKjfTmuoWHLQLi6hnF+cvCsEFiJZ4AbF+DgmO6TarJ8O05t8zvnOwJlNCASPZRH/JmF8tX0hoHuAQ==</ds:X509Certificate>\n"+
@@ -766,7 +766,7 @@ func (test *IdentityProviderTest) TestMakeResponse(c *C) {
 		"  <samlp:Status>\n"+
 		"    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n"+
 		"  </samlp:Status>\n"+
-		"  <this-is-an-encrypted-assertion xmlns=\"http://www.w3.org/XML/1998/namespace\"/>\n"+
+		"  <this-is-an-encrypted-assertion/>\n"+
 		"</samlp:Response>\n")
 }
 
@@ -965,16 +965,16 @@ func (test *IdentityProviderTest) TestCanHandleUnencryptedResponse(c *C) {
 		"    </saml:AuthnStatement>\n"+
 		"    <saml:AttributeStatement>\n"+
 		"      <saml:Attribute FriendlyName=\"Email address\" Name=\"email\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\">\n"+
-		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"></saml:AttributeValue>\n"+
+		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"/>\n"+
 		"      </saml:Attribute>\n"+
 		"      <saml:Attribute FriendlyName=\"Full name\" Name=\"name\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\">\n"+
-		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"></saml:AttributeValue>\n"+
+		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"/>\n"+
 		"      </saml:Attribute>\n"+
 		"      <saml:Attribute FriendlyName=\"Given name\" Name=\"first_name\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\">\n"+
-		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"></saml:AttributeValue>\n"+
+		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"/>\n"+
 		"      </saml:Attribute>\n"+
 		"      <saml:Attribute FriendlyName=\"Family name\" Name=\"last_name\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\">\n"+
-		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"></saml:AttributeValue>\n"+
+		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\"/>\n"+
 		"      </saml:Attribute>\n"+
 		"      <saml:Attribute FriendlyName=\"uid\" Name=\"urn:oid:0.9.2342.19200300.100.1.1\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\">\n"+
 		"        <saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\">alice</saml:AttributeValue>\n"+

--- a/service_provider.go
+++ b/service_provider.go
@@ -392,16 +392,17 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 	}
 	retErr.Response = string(rawResponseBuf)
 
-	// XML Validation
+	// XML Validation using https://github.com/mattermost/xml-roundtrip-validator;
+	// CVE-2020-29509 (unstable attributes), CVE-2020-29510 (unstable directives), CVE-2020-29511 (unstable elements)
 	if err := xrv.Validate(strings.NewReader(string(rawResponseBuf))); err != nil {
-		retErr.PrivateErr = fmt.Errorf("invalid xml response: %s", err)
+		retErr.PrivateErr = fmt.Errorf("invalid xml response: %w", err)
 		return nil, requestID, retErr
 	}
 
 	// do some validation first before we decrypt
 	resp := Response{}
 	if err := xml.Unmarshal(rawResponseBuf, &resp); err != nil {
-		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %v", err)
+		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %w", err)
 		return nil, requestID, retErr
 	}
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -392,6 +392,7 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 	}
 	retErr.Response = string(rawResponseBuf)
 
+	// XML Validation
 	if err := xrv.Validate(strings.NewReader(string(rawResponseBuf))); err != nil {
 		retErr.PrivateErr = fmt.Errorf("invalid xml response: %s", err)
 		return nil, requestID, retErr


### PR DESCRIPTION
Added XML Validation.

Summary:

- Used https://github.com/mattermost/xml-roundtrip-validator and validated XML
- Fixed and added unit tests