### PR TITLE
AUTH-2414: Fixes for PingFederate

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -435,7 +435,11 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 	// AUTH-2414: This will allow IDP-Initiated requests to succeed if possibleRequestIDs is empty.
 	// This is a typical case with PingFederate.
 	// Ref: https://github.com/crewjam/saml/issues/151#issuecomment-435626671
-	if !requestIDvalid && sp.AllowIDPInitiated == false {
+	if !requestIDvalid && sp.AllowIDPInitiated == true {
+		requestIDvalid = true
+	}
+
+	if !requestIDvalid {
 		retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
 		return nil, requestID, retErr
 	}
@@ -559,7 +563,11 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 		//
 		// Finally, it is unclear that there is significant security value in checking InResponseTo when we allow
 		// IDP initiated assertions.
-		if !requestIDvalid && sp.AllowIDPInitiated == false {
+		if !requestIDvalid && sp.AllowIDPInitiated == true {
+			requestIDvalid = true
+		}
+
+		if !requestIDvalid {
 			return fmt.Errorf("SubjectConfirmation one of the possible request IDs (%v)", possibleRequestIDs)
 		}
 		if subjectConfirmation.SubjectConfirmationData.Recipient != sp.AcsURL.String() {

--- a/time_test.go
+++ b/time_test.go
@@ -52,6 +52,6 @@ func (test *TimeTest) TestParse(c *C) {
 	{
 		var t RelaxedTime
 		err := t.UnmarshalText([]byte("1981-02-03T14:15:16Z04:00"))
-		c.Assert(err, ErrorMatches, "parsing time \"1981-02-03T14:15:16Z04:00\": extra text: 04:00")
+		c.Assert(err, ErrorMatches, "parsing time \"1981-02-03T14:15:16Z04:00\": extra text: \"04:00\"")
 	}
 }


### PR DESCRIPTION
This PR allows IdP-initiated requests that have empty request IDs to fix PingFederate default setups. This is a backported feature from the upstream based on https://github.com/crewjam/saml/issues/151 and https://github.com/crewjam/saml/issues/268. A new `ServiceProvider.AllowIDPInitiated` bool value toggles this functionality.

Also in this PR allows the ACS response `Destination` validation to be optional since PF doesn't send it, although it is required with signed requests as per SAML 2. Otherwise the PF apps would need to be modified. Ref: https://support.pingidentity.com/s/question/0D51W00006EytamSAB/i-need-to-set-destination-in-my-saml-response

JIRA: https://invisionapp.atlassian.net/browse/AUTH-2414