### PR TITLE
AUTH-2448: Disable signature check in encrypted response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/russellhaering/goxmldsig v1.1.0
+	github.com/russellhaering/goxmldsig v1.1.1-0.20201210191726-3541f5e554ee
 	github.com/zenazn/goji v1.0.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russellhaering/goxmldsig v1.1.0 h1:lK/zeJie2sqG52ZAlPNn1oBBqsIsEKypUUBGpYYF6lk=
 github.com/russellhaering/goxmldsig v1.1.0/go.mod h1:QK8GhXPB3+AfuCrfo0oRISa9NfzeCpWmxeGnqEpDF9o=
+github.com/russellhaering/goxmldsig v1.1.1-0.20201210191726-3541f5e554ee h1:crOrBljowvmyKZv2tCRyngWUPHyMHeKRaycSJuEw5/Q=
+github.com/russellhaering/goxmldsig v1.1.1-0.20201210191726-3541f5e554ee/go.mod h1:QK8GhXPB3+AfuCrfo0oRISa9NfzeCpWmxeGnqEpDF9o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=

--- a/service_provider.go
+++ b/service_provider.go
@@ -710,12 +710,16 @@ func (sp *ServiceProvider) ParseXMLResponse(decodedResponseXML []byte, possibleR
 			retErr.PrivateErr = err
 			return nil, retErr
 		}
+		/* BUG(gus): Disabling this validation because the transforms in goxmldsig v1.1.0 are broken.
+		             So even if you have a correct digest it will fail. Once this is fixed, there are PRs,
+			     we need to reenable this.
 		if responseSigned {
 			if err := sp.validateSigned(doc.Root()); err != nil {
 				retErr.PrivateErr = err
 				return nil, retErr
 			}
 		}
+		*/
 
 		var key interface{} = sp.Key
 		keyEl := doc.FindElement("//EncryptedAssertion/EncryptedKey")


### PR DESCRIPTION
This PR disables signature checks when validating encrypted assertion responses. The [russellhaering/goxmldsig](https://github.com/russellhaering/goxmldsig) pkg has bugs related to the transforms that haven't been addressed. Once these bugs are fixed we will reenable the signature check. Also the pkg **goxmldsig** was updated to master to fix a crash in the handling null canonicalization values. 

Signature bugs: https://github.com/russellhaering/goxmldsig/issues/65 https://github.com/russellhaering/goxmldsig/issues/43 

JIRA: https://invisionapp.atlassian.net/browse/AUTH-2448